### PR TITLE
Drop loop argument from async function calls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     zip_safe=True,
     packages=find_packages("src"),
     package_dir={"": "src"},
-    python_requires=">=3.6.*",
+    python_requires=">=3.8",
     install_requires=[
         "aio-krpc-server==0.0.7"
     ]

--- a/src/aiobtdht/dht.py
+++ b/src/aiobtdht/dht.py
@@ -65,7 +65,7 @@ class DHT(KRPCServer):
 
     def _run_future(self, *args):
         for fut in args:
-            asyncio.ensure_future(fut, loop=self.loop)
+            asyncio.ensure_future(fut)
 
     # region Server methods
     def ping(self, addr, id):
@@ -212,8 +212,7 @@ class DHT(KRPCServer):
         responses = filter(
             lambda response: response,
             await asyncio.gather(
-                *(self.remote_ping(node[1]) for node in self.routing_table.enum_nodes_for_refresh()),
-                loop=self.loop
+                *(self.remote_ping(node[1]) for node in self.routing_table.enum_nodes_for_refresh())
             )
         )
 
@@ -243,8 +242,7 @@ class DHT(KRPCServer):
         return filter(
             lambda response: response and response[1]["id"] != self.id,
             await asyncio.gather(
-                *(cb(peer) for peer in peers),
-                loop=self.loop
+                *(cb(peer) for peer in peers)
             )
         )
 


### PR DESCRIPTION
Deprecated since version 3.8, was removed in version 3.10.

Signed-off-by: Martin Weinelt <hexa@darmstadt.ccc.de>