### PR TITLE
Add support for sampling infohashes (BEP51)

### DIFF
--- a/src/aiobtdht/dht.py
+++ b/src/aiobtdht/dht.py
@@ -23,6 +23,8 @@ from .schemas import PING_ARGS
 from .schemas import PING_ARGS_REMOTE
 from .schemas import PING_RESULT
 from .schemas import PING_RESULT_REMOTE
+from .schemas import SAMPLE_INFOHASHES_ARGS_REMOTE
+from .schemas import SAMPLE_INFOHASHES_RESULT_REMOTE
 from .utils import calc_sha1
 from .utils import call_timeout
 from .utils import decode_info_hash
@@ -195,6 +197,15 @@ class DHT(KRPCServer):
             timeout=timeout,
             arg_schema=ANNOUNCE_PEER_ARGS_REMOTE,
             result_schema=ANNOUNCE_PEER_RESULT_REMOTE
+        )
+
+    async def remote_sample_infohashes(self, addr, target_id, timeout=3):
+        return await self._remote_call(
+            addr, "sample_infohashes",
+            kwargs={"id": self.id, "target": target_id},
+            timeout=timeout,
+            arg_schema=SAMPLE_INFOHASHES_ARGS_REMOTE,
+            result_schema=SAMPLE_INFOHASHES_RESULT_REMOTE
         )
 
     async def _add_or_update_node(self, id_, addr):

--- a/src/aiobtdht/schemas.py
+++ b/src/aiobtdht/schemas.py
@@ -1,6 +1,7 @@
 from .utils import decode_id
 from .utils import decode_nodes
 from .utils import decode_peers
+from .utils import decode_samples
 from .utils import encode_id
 from .utils import encode_nodes
 from .utils import encode_peers
@@ -18,6 +19,8 @@ _VALUES_ENCODE_SCHEMA = {"type": "list", "coerce": encode_peers, "schema": {"typ
 _VALUES_DECODE_SCHEMA = {"type": "list", "coerce": decode_peers}
 
 _TOKEN_SCHEMA = {"type": "binary"}
+
+_SAMPLES_DECODE_SCHEMA = {"type": "list", "coerce": decode_samples, "required": False}
 
 PING_ARGS = {"id": {"required": True, **_ID_DECODE_SCHEMA}}
 PING_RESULT = {"id": {"required": True, **_ID_ENCODE_SCHEMA}}
@@ -68,3 +71,13 @@ ANNOUNCE_PEER_ARGS_REMOTE = {
     "token": {"required": True, **_TOKEN_SCHEMA},
     "implied_port": {"type": "integer", "required": False, "min": 0, "max": 1}}
 ANNOUNCE_PEER_RESULT_REMOTE = {"id": {"required": True, **_ID_DECODE_SCHEMA}}
+
+SAMPLE_INFOHASHES_ARGS_REMOTE = {
+    "id": {"required": True, **_ID_ENCODE_SCHEMA},
+    "target": {"required": True, **_ID_ENCODE_SCHEMA}}
+SAMPLE_INFOHASHES_RESULT_REMOTE = {
+    "id": {"required": True, **_ID_DECODE_SCHEMA},
+    "interval": {"type": "integer", "required": False},
+    "nodes": _NODES_DECODE_SCHEMA,
+    "num": {"type": "integer", "required": False},
+    "samples": _SAMPLES_DECODE_SCHEMA}

--- a/src/aiobtdht/utils.py
+++ b/src/aiobtdht/utils.py
@@ -27,6 +27,10 @@ def decode_info_hash(info_hash):
     return decode_id(info_hash)
 
 
+def decode_samples(samples):
+    return [decode_id(samples[i:i+20]) for i in range(0, len(samples), 20)]
+
+
 def encode_addr(addr):
     host, port = addr
     return b"".join((inet_aton(host), port.to_bytes(2, "big")))


### PR DESCRIPTION
Adds a call that queries a target peer for infohashes.

Signed-off-by: Martin Weinelt <hexa@darmstadt.ccc.de>

I'm a bit unclear on the meaning of the `_REMOTE` schemas, probably one is for incoming requests, the other for outgoing? Looking for clarification here.