### PR TITLE
Add __eq__ for Node

### DIFF
--- a/src/aiobtdht/routing_table/node.py
+++ b/src/aiobtdht/routing_table/node.py
@@ -10,3 +10,9 @@ class Node:
     @property
     def addr(self):
         return self._addr
+
+    def __eq__(self, __o: object) -> bool:
+        if not isinstance(__o, Node):
+            return False
+
+        return self.id == __o.id and self.addr == __o.addr


### PR DESCRIPTION
When performing equality operations with the `Node` class you end up with fake results since two different instances of `Node` with the same attributes returns `False`.

This also makes it possible to use `Node` in sets and check for membership.